### PR TITLE
fix: missing ObjectAddPropertyOperation reference transform pair

### DIFF
--- a/src/main/scala/com/convergencelabs/convergence/server/backend/services/domain/model/ot/xform/TransformationFunctionRegistry.scala
+++ b/src/main/scala/com/convergencelabs/convergence/server/backend/services/domain/model/ot/xform/TransformationFunctionRegistry.scala
@@ -114,6 +114,9 @@ private[model] class TransformationFunctionRegistry {
   rtfs.register[StringRemoveOperation, RangeReferenceValues](StringRemoveRangeTF)
   rtfs.register[StringSetOperation, RangeReferenceValues](StringSetRangeTF)
 
+  rtfs.register[ObjectAddPropertyOperation, IndexReferenceValues](ObjectAddPropertyIndexTF)
+  rtfs.register[ObjectAddPropertyOperation, RangeReferenceValues](ObjectAddPropertyRangeTF)
+
   def getOperationTransformationFunction[S <: DiscreteOperation, C <: DiscreteOperation](s: S, c: C): Option[OperationTransformationFunction[S, C]] = {
     otfs.getOperationTransformationFunction(s, c)
   }

--- a/src/main/scala/com/convergencelabs/convergence/server/backend/services/domain/model/ot/xform/reference/ObjectAddPropertyIndexTF.scala
+++ b/src/main/scala/com/convergencelabs/convergence/server/backend/services/domain/model/ot/xform/reference/ObjectAddPropertyIndexTF.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2019 - Convergence Labs, Inc.
+ *
+ * This file is part of the Convergence Server, which is released under
+ * the terms of the GNU General Public License version 3 (GPLv3). A copy
+ * of the GPLv3 should have been provided along with this file, typically
+ * located in the "LICENSE" file, which is part of this source code package.
+ * Alternatively, see <https://www.gnu.org/licenses/gpl-3.0.html> for the
+ * full text of the GPLv3 license, if it was not provided.
+ */
+
+package com.convergencelabs.convergence.server.backend.services.domain.model.ot.xform.reference
+
+import com.convergencelabs.convergence.server.backend.services.domain.model.ot.ObjectAddPropertyOperation
+import com.convergencelabs.convergence.server.backend.services.domain.model.ot.xform.{IndexTransformer, ReferenceTransformationFunction}
+import com.convergencelabs.convergence.server.model.domain.model.IndexReferenceValues
+
+object ObjectAddPropertyIndexTF extends ReferenceTransformationFunction[ObjectAddPropertyOperation, IndexReferenceValues] {
+  def transform(op: ObjectAddPropertyOperation, values: IndexReferenceValues): Option[IndexReferenceValues] = {
+    val xFormed = IndexTransformer.handleInsert(values.values, 0, 0)
+    Some(IndexReferenceValues(xFormed))
+  }
+}

--- a/src/main/scala/com/convergencelabs/convergence/server/backend/services/domain/model/ot/xform/reference/ObjectAddPropertyRangeTF.scala
+++ b/src/main/scala/com/convergencelabs/convergence/server/backend/services/domain/model/ot/xform/reference/ObjectAddPropertyRangeTF.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2019 - Convergence Labs, Inc.
+ *
+ * This file is part of the Convergence Server, which is released under
+ * the terms of the GNU General Public License version 3 (GPLv3). A copy
+ * of the GPLv3 should have been provided along with this file, typically
+ * located in the "LICENSE" file, which is part of this source code package.
+ * Alternatively, see <https://www.gnu.org/licenses/gpl-3.0.html> for the
+ * full text of the GPLv3 license, if it was not provided.
+ */
+
+package com.convergencelabs.convergence.server.backend.services.domain.model.ot.xform.reference
+
+import com.convergencelabs.convergence.server.backend.services.domain.model.ot.ObjectAddPropertyOperation
+import com.convergencelabs.convergence.server.backend.services.domain.model.ot.xform.{IndexTransformer, ReferenceTransformationFunction}
+import com.convergencelabs.convergence.server.model.domain.model.RangeReferenceValues
+import com.convergencelabs.convergence.server.backend.services.domain.model.reference.RangeReference
+
+object ObjectAddPropertyRangeTF extends ReferenceTransformationFunction[ObjectAddPropertyOperation, RangeReferenceValues] {
+  def transform(op: ObjectAddPropertyOperation, values: RangeReferenceValues): Option[RangeReferenceValues] = {
+    val xFormedRanges = values.values map { range =>
+      val xFormed = IndexTransformer.handleInsert(List(range.to, range.from), 0, 0)
+      RangeReference.Range(xFormed.head, xFormed.last)
+    }
+    Some(RangeReferenceValues(xFormedRanges))
+  }
+}


### PR DESCRIPTION
If there are many properties and reference created at the same time by client A,  then operationHistoryCache will still have ObjectAddPropertyOperation  when client B get called with processRemoteReferenceSet().