### PR TITLE
Fixes CVE-2021-45105, 45046, and 44228

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,7 +18,7 @@ object Dependencies {
     val akka      = "2.6.15"
     val akkaHttp  = "10.2.4"
     val orientDb  = "3.0.37"
-    val log4j     = "2.14.1"
+    val log4j     = "2.17.0"
     val jackson   = "2.11.4"
   }
 


### PR DESCRIPTION
Fixes CVE-2021-45105, CVE-2021-45046, and CVE-2021-44228 by bumping log4j from 2.14.1 to 2,17.0
Cluster Seed and Docker images should also be updated.